### PR TITLE
Fixed a random bug in react-dom development

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLazyComponent.js
+++ b/packages/react-reconciler/src/ReactFiberLazyComponent.js
@@ -42,7 +42,7 @@ export function readLazyComponentType<T>(lazyComponent: LazyComponent<T>): T {
                   false,
                   'lazy: Expected the result of a dynamic import() call. ' +
                     'Instead received: %s\n\nYour code should look like: \n  ' +
-                    "const MyComponent = lazy(() => import('./MyComponent'))",
+                    'const MyComponent = lazy(() => import(\'./MyComponent\'))',
                   moduleObject,
                 );
               }


### PR DESCRIPTION
I found a random bug in react-dom, but only in development:
```
ERROR in ./node_modules/react-dom/cjs/react-dom.development.js
Module build failed (from ./node_modules/babel-loader/lib/index.js):
SyntaxError: node_modules/react-dom/cjs/react-dom.development.js: Unexpected token, expected ";" (13463:228)
```

A string was not escaped correctly, but only in development it throws this error.